### PR TITLE
Fix for "And" in single indexed SPROCs

### DIFF
--- a/Templates/Database/StoredProcedures/StoredProcedures.cst
+++ b/Templates/Database/StoredProcedures/StoredProcedures.cst
@@ -1113,7 +1113,10 @@ public string GetBySuffix(IList<ColumnSchema> columns)
     System.Text.StringBuilder bySuffix = new System.Text.StringBuilder();
     foreach(var column in columns.AsIndexedEnumerable())
 	{
-	    if (!column.IsFirst) bySuffix.Append("And");
+	if (column.Index > 0) { 
+            // Only add the and before subsequent columns
+            bySuffix.Append("And");
+        }
 	    bySuffix.Append(column.Value.Name);
 	}
 	


### PR DESCRIPTION
Only add the and before subsequent columns: 
Tested on VistaDBPetshop Item Table.

_Results Before Change: _
[ItemSelectBy**And**ProductId]
[ItemSelectBy**And**Supplier]
ItemSelectBy**And**ProductIdItemIdListPriceName]
[ItemSelectByAndItemId]

_Results after Change: _
[ItemSelectByProductId]
[ItemSelectBySupplier]
[ItemSelectByProductId**And**ItemId**And**ListPrice**And**Name]
[ItemSelectByItemId]