### PR TITLE
Fixes #721 [dbsnapshot] Allow Azure and other cloud-based server sources with port number.

### DIFF
--- a/Templates/Database/DbSnapshot/DbSnapshot.cst
+++ b/Templates/Database/DbSnapshot/DbSnapshot.cst
@@ -261,6 +261,7 @@ public string ParseServerName( SchemaExplorer.DatabaseSchema db )
             String regexptrn = @"^.*\:(\w+)(\..*$)";
             String InPutString = _serverName.Trim();
             _serverName = Regex.Replace(InPutString, regexptrn, "$1", ro); 
+            CleanName( _serverName ); //insure the name can be used to create a folder safely
         }
 		
         if ( _serverName.Trim() == "") { _serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName); } // edge case 

--- a/Templates/Database/DbSnapshot/DbSnapshot.cst
+++ b/Templates/Database/DbSnapshot/DbSnapshot.cst
@@ -246,24 +246,19 @@ public string ParseServerName( SchemaExplorer.DatabaseSchema db )
 	
 	_serverName = conn.DataSource;
 	conn = null;
-	if (    _serverName.Trim().StartsWith(".")
-            || _serverName.Trim().StartsWith("(local)") 
-			|| _serverName.Trim().StartsWith("127.0.0.1") 
-        ) {          
-            _serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName);
-        } else if (
-            // Allow a cloud source with port  TCP:xxx,1111 or a UDP:xxxx,1433 
-            _serverName.Trim().Contains(":") /* eg tcp:myCloudData.database.windows.net,5588 */
-        ) {
-            const RegexOptions ro = RegexOptions.IgnoreCase; // | RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline | RegexOptions.Compiled ;
-            String regexptrn = @"^.*\:(\w+)(\..*$)";
-            String InPutString = _serverName.Trim();
-            _serverName = Regex.Replace(InPutString, regexptrn, "$1", ro); 
-            CleanName( _serverName ); //insure the name can be used to create a folder safely
-        }
-		
-        if ( _serverName.Trim() == "") { _serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName); } // edge case 
-        
+
+    string name = _serverName.Trim();
+    if (name.StartsWith(".") || name.StartsWith("(local)") || name.StartsWith("127.0.0.1")) {
+        _serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName);
+    } else if (name.Contains(":")) {
+        // Allow a cloud source with port  TCP:xxx,1111 or a UDP:xxxx,1433 eg tcp:myCloudData.database.windows.net,5588
+        _serverName = CleanName(Regex.Replace(name, @"^.*\:(\w+)(\..*$)", "$1", RegexOptions.IgnoreCase)); 
+    }
+
+    if (String.IsNullOrEmpty(_serverName.Trim())) {
+        _serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName); 
+    }
+
 	return _serverName;
 }
 

--- a/Templates/Database/DbSnapshot/DbSnapshot.cst
+++ b/Templates/Database/DbSnapshot/DbSnapshot.cst
@@ -8,9 +8,7 @@
 		DBSnaptshot will create a file for every database object 
 		and if configured will attempt to script your database.
 	Remarks:
-		Only tested with Microsoft SQL Server 
-        and Azure MS SQL 
-        
+		Only tested with Microsoft SQL Server and Azure MS SQL
 --%>
 <%@ CodeTemplate Language="C#" TargetLanguage="TEXT" Src="SubTemplates/DbSnapshot.CodeBehind.cs" Inherits="_Main" Description="Scripts DatabaseObjects" Debug="True" %>
 <%@ Property Name="SourceDatabase" Type="SchemaExplorer.DatabaseSchema" Category="1. Context" Description="Database that the documentation should be based on." %>

--- a/Templates/Database/DbSnapshot/DbSnapshot.cst
+++ b/Templates/Database/DbSnapshot/DbSnapshot.cst
@@ -1,12 +1,16 @@
 ﻿<%--
 	Author: 
 		Todd Carrico
-	
+
+    Update: Joe Johnston 
+        Allow Azure and other cloud based servers DBs
 	Description:
 		DBSnaptshot will create a file for every database object 
 		and if configured will attempt to script your database.
 	Remarks:
-		Only tested with Microsoft SQL Server
+		Only tested with Microsoft SQL Server 
+        and Azure MS SQL 
+        
 --%>
 <%@ CodeTemplate Language="C#" TargetLanguage="TEXT" Src="SubTemplates/DbSnapshot.CodeBehind.cs" Inherits="_Main" Description="Scripts DatabaseObjects" Debug="True" %>
 <%@ Property Name="SourceDatabase" Type="SchemaExplorer.DatabaseSchema" Category="1. Context" Description="Database that the documentation should be based on." %>
@@ -244,11 +248,23 @@ public string ParseServerName( SchemaExplorer.DatabaseSchema db )
 	
 	_serverName = conn.DataSource;
 	conn = null;
-	if (_serverName.Trim().StartsWith(".")
-			|| _serverName.Trim().StartsWith("(local)") 
-			|| _serverName.Trim().StartsWith("127.0.0.1"))
-		_serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName);
+	if (    _serverName.Trim().StartsWith(".")
+            || _serverName.Trim().StartsWith("(local)") 
+			|| _serverName.Trim().StartsWith("127.0.0.1") 
+        ) {          
+            _serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName);
+        } else if (
+            // Allow a cloud source with port  TCP:xxx,1111 or a UDP:xxxx,1433 
+            _serverName.Trim().Contains(":") /* eg tcp:myCloudData.database.windows.net,5588 */
+        ) {
+            const RegexOptions ro = RegexOptions.IgnoreCase; // | RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline | RegexOptions.Compiled ;
+            String regexptrn = @"^.*\:(\w+)(\..*$)";
+            String InPutString = _serverName.Trim();
+            _serverName = Regex.Replace(InPutString, regexptrn, "$1", ro); 
+        }
 		
+        if ( _serverName.Trim() == "") { _serverName = CleanName(System.Windows.Forms.SystemInformation.ComputerName); } // edge case 
+        
 	return _serverName;
 }
 


### PR DESCRIPTION
The issue wasn't permissions exactly. It was the inability to create a directory from the server name/ server source when it's name is like tcp:myCloudData.database.windows.net,5588.  So I have added a rudimentary check in the ParseServerName function to look for a colon.  

With the example above I choose **myCloudData** as the parsed server name.  I also check for a blank name and if it is I select the computer name as a last resort otherwise we would create a hidden folder eg .MyDatabaseName 

I hope this is clear and I am open to input and suggestion. 